### PR TITLE
Stabilize boolean operations and document Blender 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Find under Edit → Preferences → Add-ons → Poly Source.
 ---
 
 ### Compatibility
-- **Blender:** 4.2+ (defined in `blender_manifest.toml`). Some UI icons adapt based on Blender version.
+- **Blender:** 4.2+ including Blender 5.x (minimum version is defined in `blender_manifest.toml`).
+- **Booleans:** boolean operators use Blender's `EXACT` solver path for stable, predictable results across Blender 4.2+ and 5.x.
 - **Other add-ons:** some hotkeys or header insertions may overlap; adjust in Preferences as needed. Cylinder Optimizer's "Rounding Up" mode requires the LoopTools add-on.
 
 ---


### PR DESCRIPTION
### Motivation
- Make boolean operators more stable and deterministic by removing context-sensitive failure modes and validating selection before running operations.  
- Ensure the add-on behaves consistently on Blender 4.2+ and Blender 5.x by preferring a stable solver path and enabling tolerant settings when available.

### Description
- Add a `poll` and `_validate_selection` to boolean operators to require `OBJECT` mode, an active `MESH` object, and one or more mesh operands, and to report clear errors on invalid selection.  
- Force boolean modifiers to use the `EXACT` solver when available and enable `use_hole_tolerant` if the API exposes it for more predictable results across versions.  
- Harden context handling by switching to `OBJECT` mode before preparing objects and applying modifiers using a more complete `bpy.context.temp_override` (including `object`, `active_object`, `selected_objects`, and `selected_editable_objects`) to reduce `modifier_apply` context failures.  
- Make `Bool Slice` safer by validating operands up front, iterating over validated operands, and only assigning the active object to the slice copy if a copy was actually created.  
- Update `README.md` compatibility notes to explicitly mention Blender 5.x and the boolean solver behavior.

### Testing
- Ran `python -m py_compile utils/ops.py __init__.py utils/utils.py` to verify there are no syntax errors and the files compile successfully.  
- Basic static checks completed; `py_compile` returned success indicating the modified modules are syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dee2cfa98832ca23b888e02339d1d)