### PR TITLE
Add +X triangle pointer to Unit Grid and refresh Unit Grid panel layout

### DIFF
--- a/envira_grid.py
+++ b/envira_grid.py
@@ -174,6 +174,34 @@ def box():
     return face_co, faces_indices
 
 
+def triangle_pointer_lines():
+    """Build a small +X direction pointer outside the outer frame."""
+    settings = bpy.context.scene.poly_source
+
+    x = settings.unit_x / 100.0
+    y = settings.unit_y / 100.0
+    if settings.one2one:
+        y = x
+    z = settings.offset_z / 100.0
+
+    short_side = max(1e-6, min(abs(x), abs(y)))
+
+    offset = short_side * 0.04
+    tip_len = short_side * 0.10
+    base_half = short_side * 0.08
+
+    x_base = (x / 2.0) + offset
+    x_tip = x_base + tip_len
+
+    tri_lines = [
+        (x_base, base_half, z), (x_base, -base_half, z),
+        (x_base, -base_half, z), (x_tip, 0.0, z),
+        (x_tip, 0.0, z), (x_base, base_half, z),
+    ]
+
+    return tri_lines
+
+
 if bpy.app.version >= (4, 0, 0):
     shader = gpu.shader.from_builtin('UNIFORM_COLOR')
 else:
@@ -213,6 +241,11 @@ def draw_grid(self, context):
         c = props.color_grid
         shader.uniform_float("color", (c[0], c[1], c[2], c[3] / 2.0))
         grid_batch.draw(shader)
+
+    tri_co = triangle_pointer_lines()
+    tri_batch = batch_for_shader(shader, 'LINES', {"pos": tri_co})
+    shader.uniform_float("color", props.color_grid)
+    tri_batch.draw(shader)
 
     lines_co = lines()
     edges_batch = batch_for_shader(shader, 'LINES', {"pos": lines_co})

--- a/ui/panels.py
+++ b/ui/panels.py
@@ -39,34 +39,32 @@ class PS_PT_unit_grid(Panel):
 
     def draw(self, context):
         settings = context.scene.poly_source
-        if not settings.draw_grid:
-            return
+        if settings.draw_grid:
+            layout = self.layout
 
-        layout = self.layout
+            row = layout.row()
+            row.prop(settings, 'box', text="Draw Box", toggle=True)
+            row.prop(settings, 'grid_xray', toggle=True)
+            row.prop(settings, 'one2one', toggle=True)
 
-        row = layout.row()
-        row.prop(settings, 'box', text="Draw Box", toggle=True, icon='CUBE')
-        row.prop(settings, 'grid_xray', toggle=True)
-        row.prop(settings, 'one2one', toggle=True)
-
-        row = layout.row(align=True)
-        row.prop(settings, 'unit_x')
-        if not settings.one2one:
-            row.prop(settings, 'unit_y')
-        if settings.box:
-            row.prop(settings, 'height')
-
-        row = layout.row()
-        row.prop(settings, 'padding')
-        row.prop(settings, 'offset_z')
-
-        if settings.draw_sub_grid:
             row = layout.row(align=True)
-            row.prop(settings, 'draw_sub_grid', text="", icon='MESH_GRID')
-            row.prop(settings, 'grid_cell_size')
-            row.prop(settings, 'grid_align_center', text="", icon='SNAP_FACE_CENTER')
-        else:
-            layout.prop(settings, 'draw_sub_grid')
+            row.prop(settings, 'unit_x')
+            if not settings.one2one:
+                row.prop(settings, 'unit_y')
+            if settings.box:
+                row.prop(settings, 'height')
+
+            row = layout.row()
+            row.prop(settings, 'padding')
+            row.prop(settings, 'offset_z')
+
+            if settings.draw_sub_grid:
+                row = layout.row(align=True)
+                row.prop(settings, 'draw_sub_grid', text="", icon='MESH_GRID')
+                row.prop(settings, 'grid_cell_size')
+                row.prop(settings, 'grid_align_center', text="", icon='SNAP_FACE_CENTER')
+            else:
+                layout.prop(settings, 'draw_sub_grid')
 
 
 class PS_PT_check(Panel):


### PR DESCRIPTION
### Motivation
- Provide the visual +X direction hint used in the other addon by adding a small triangle pointer to the Unit Grid overlay while keeping Poly Source naming and settings bindings.
- Make the Unit Grid UI follow the refreshed structure so controls are only shown when `draw_grid` is enabled and grouped similarly to the updated design.

### Description
- Added `triangle_pointer_lines()` to `envira_grid.py` which computes a small +X directional triangle based on `poly_source` dimensions and offset and returns line coordinates.
- Integrated the triangle into `draw_grid()` by creating a `LINES` batch and drawing it with `props.color_grid` next to the existing sub-grid and box drawing code in `envira_grid.py`.
- Updated `PS_PT_unit_grid` in `ui/panels.py` to only render the panel content when `settings.draw_grid` is enabled and reorganized the rows so `box`, `grid_xray`, `one2one`, size fields, padding/offset and sub-grid controls follow the new layout flow.
- Preserved existing Poly Source naming and bindings, including `PS_GT_grid`, `PS_GGT_grid`, `PS_PT_unit_grid` and uses of `context.scene.poly_source.*`.

### Testing
- Ran `python -m py_compile envira_grid.py ui/panels.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e22778864832c86831ba886b8c535)